### PR TITLE
chore: bump torch due to security vulnerability

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,8 +1,8 @@
 unstructured>=0.2.4
 unstructured-api-tools>=0.4.4
 layoutparser>=0.3.4
-torch==1.13.0
-torchvision==0.14.0
+torch>=1.13.1
+torchvision>0.14.0
 pdf2image==1.16.0
 ratelimit
 iopath==0.1.7

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -122,6 +122,16 @@ numpy==1.23.5
     #   pandas
     #   scipy
     #   torchvision
+nvidia-cublas-cu11==11.10.3.66
+    # via
+    #   nvidia-cudnn-cu11
+    #   torch
+nvidia-cuda-nvrtc-cu11==11.7.99
+    # via torch
+nvidia-cuda-runtime-cu11==11.7.99
+    # via torch
+nvidia-cudnn-cu11==8.5.0.96
+    # via torch
 opencv-python==4.6.0.66
     # via layoutparser
 packaging==22.0
@@ -214,11 +224,11 @@ tomli==2.0.1
     #   build
     #   mypy
     #   pep517
-torch==1.13.0
+torch==1.13.1
     # via
     #   -r requirements/base.in
     #   torchvision
-torchvision==0.14.0
+torchvision==0.14.1
     # via -r requirements/base.in
 tornado==6.2
     # via jupyter-client
@@ -268,7 +278,10 @@ webencodings==0.5.1
 websockets==10.4
     # via uvicorn
 wheel==0.38.4
-    # via pip-tools
+    # via
+    #   nvidia-cublas-cu11
+    #   nvidia-cuda-runtime-cu11
+    #   pip-tools
 wrapt==1.14.1
     # via deprecated
 zipp==3.11.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,10 +6,6 @@
 #
 anyio==3.6.2
     # via jupyter-server
-appnope==0.1.3
-    # via
-    #   ipykernel
-    #   ipython
 argon2-cffi==21.3.0
     # via
     #   jupyter-server

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -15,13 +15,15 @@ attrs==22.1.0
 backcall==0.2.0
     # via ipython
 black==22.12.0
-    # via -r test.in
+    # via -r requirements/test.in
 click==8.1.3
     # via black
 coverage[toml]==6.5.0
     # via pytest-cov
 decorator==5.1.1
     # via ipython
+exceptiongroup==1.1.0
+    # via pytest
 execnb==0.1.4
     # via nbdev
 executing==1.2.0
@@ -32,7 +34,7 @@ fastcore==1.5.27
     #   ghapi
     #   nbdev
 flake8==6.0.0
-    # via -r test.in
+    # via -r requirements/test.in
 ghapi==1.0.3
     # via nbdev
 iniconfig==1.1.1
@@ -46,13 +48,13 @@ matplotlib-inline==0.1.6
 mccabe==0.7.0
     # via flake8
 mypy==0.991
-    # via -r test.in
+    # via -r requirements/test.in
 mypy-extensions==0.4.3
     # via
     #   black
     #   mypy
 nbdev==2.3.9
-    # via -r test.in
+    # via -r requirements/test.in
 packaging==22.0
     # via
     #   fastcore
@@ -85,7 +87,7 @@ pygments==2.13.0
 pytest==7.2.0
     # via pytest-cov
 pytest-cov==4.0.0
-    # via -r test.in
+    # via -r requirements/test.in
 pyyaml==6.0
     # via nbdev
 six==1.16.0
@@ -94,12 +96,20 @@ six==1.16.0
     #   astunparse
 stack-data==0.6.2
     # via ipython
+tomli==2.0.1
+    # via
+    #   black
+    #   coverage
+    #   mypy
+    #   pytest
 traitlets==5.7.1
     # via
     #   ipython
     #   matplotlib-inline
 typing-extensions==4.4.0
-    # via mypy
+    # via
+    #   black
+    #   mypy
 watchdog==2.2.0
     # via nbdev
 wcwidth==0.2.5


### PR DESCRIPTION
Addresses issue:

> In PyTorch before trunk/89695, torch.jit.annotations.parse_type_line can cause arbitrary code execution because eval is used unsafely. The fix for this issue is available in version 1.13.1. There is a release checker in https://github.com/pytorch/pytorch/issues/89855.
