### PR TITLE
Sync version-sync.sh across repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,4 +172,4 @@ version-sync:
 	scripts/version-sync.sh \
 		-s CHANGELOG.md \
 		-f README.md api-release \
-		-f preprocessing-pipeline-family.yaml release \
+		-f preprocessing-pipeline-family.yaml release


### PR DESCRIPTION
There are currently a few versions of the `version-sync.sh` script floating around in various repos. This issue provides for updating them all to the same script.